### PR TITLE
Fix sysctl version

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -6,4 +6,4 @@ Security (CIS) Security Configuration Benchmark for Red Hat Enterprise Linux
 project_page 'https://github.com/arildjensen/cis-puppet'
 author 'Arild Jensen <ajensen@counter-attack.com>'
 
-dependency 'duritong/sysctl', '>= 3.0.0'
+dependency 'duritong/sysctl', '>= 0.0.2'


### PR DESCRIPTION
The latest version of duritong/sysctl on the forge is 0.0.2. Having the version in the Modulefile set high breaks librarian-puppet and possibly other dependency resolvers. I've knocked it down to 0.0.2.
