### PR TITLE
Fixes a typo in f0007.sh

### DIFF
--- a/files/linuxcontrols/scripts/f0007.sh
+++ b/files/linuxcontrols/scripts/f0007.sh
@@ -5,7 +5,7 @@
 
 COMMAND=`grep '^+:' /etc/group`
 
-if [ x$FILES == x ]; then 
+if [ x$COMMAND == x ]; then 
   echo pass;
 else 
   echo fail;


### PR DESCRIPTION
Previously f0007.sh could never fail. Resolves #8
