### PR TITLE
Fixing f000[23] to look before leap

### DIFF
--- a/lib/facter/f0002.rb
+++ b/lib/facter/f0002.rb
@@ -1,7 +1,9 @@
 require 'facter'
 
-Facter.add(:f0002) do
-  setcode do
-    Facter::Util::Resolution.exec("cat /var/log/control_f0002")
+if File.exist?('/var/log/control_f0002')
+  Facter.add(:f0002) do
+    setcode do
+        Facter::Util::Resolution.exec("cat /var/log/control_f0002")
+    end
   end
 end

--- a/lib/facter/f0003.rb
+++ b/lib/facter/f0003.rb
@@ -1,7 +1,9 @@
 require 'facter'
 
-Facter.add(:f0003) do
-  setcode do
-    Facter::Util::Resolution.exec("cat /var/log/control_f0003")
+if File.exist?('/var/log/control_f0003')
+  Facter.add(:f0003) do
+    setcode do
+      Facter::Util::Resolution.exec("cat /var/log/control_f0003")
+    end
   end
 end


### PR DESCRIPTION
Previously the f000[23] facts would read from their control files even
if the control files had not yet been made.
