### PR TITLE
Added ci tests for different Puppet versions instead of only bleeding edge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+env:
+  - PUPPET_GEM_VERSION=2.7.26
+  - PUPPET_GEM_VERSION=3.7.5
 matrix:
   fast_finish: true
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,10 @@
 source 'https://rubygems.org'
+puppetversion = ENV.key?('PUPPET_GEM_VERSION') ? "= #{ENV['PUPPET_GEM_VERSION']}" : ['>= 2.7']
+gem 'puppet', puppetversion
+gem 'iconv'
 
 group :development, :test do
   gem 'puppet-syntax'
   gem 'puppetlabs_spec_helper'
   gem 'puppet-lint'
-  gem 'puppet'
 end


### PR DESCRIPTION
Added 2 previous Puppet versions to the .travis file, since this Puppet module seems to fail with Puppet 4.0.0+. Hopefully we can still see succesful builds, only with older versions.