### PR TITLE
Fix fact scripts by adding quotes

### DIFF
--- a/files/linuxcontrols/scripts/f0000.sh
+++ b/files/linuxcontrols/scripts/f0000.sh
@@ -5,7 +5,7 @@
 
 COMMAND=$(ps -eZ | egrep "initrc" | egrep -vw "tr|ps|egrep|bash|awk" | tr ':' ' ' | awk '{ print $NF }')
 
-if [ x$COMMAND = x ]; 
+if [ "x$COMMAND" = "x" ]; 
   then 
     echo fail; 
   else 

--- a/files/linuxcontrols/scripts/f0001.sh
+++ b/files/linuxcontrols/scripts/f0001.sh
@@ -5,7 +5,7 @@
 
 COMMAND=`egrep -v \"^\+\" /etc/passwd | awk -F: '($1!=\"root\" && $1!=\"sync\" && $1!=\"shutdown\" && $1!=\"halt\" && $3<500 && $7!=\"/sbin/nologin\") {print $1}' 2>/dev/null`
 
-if [ x$COMMAND = x ]; 
+if [ "x$COMMAND" = "x" ]; 
   then 
     echo pass; 
   else 

--- a/files/linuxcontrols/scripts/f0002.sh
+++ b/files/linuxcontrols/scripts/f0002.sh
@@ -6,7 +6,7 @@
 FILES=`df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser -ls`
 OUTFILE=/var/log/control_f0002
 
-if [ x$FILES == x ]; then 
+if [ "x$FILES" == "x" ]; then 
   # List of unowned files is empty, so that's a pass.
   echo pass > $OUTFILE; 
 else 

--- a/files/linuxcontrols/scripts/f0003.sh
+++ b/files/linuxcontrols/scripts/f0003.sh
@@ -6,7 +6,7 @@
 FILES=`df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup -ls`
 OUTFILE=/var/log/control_f0003
 
-if [ x$FILES == x ]; then 
+if [ "x$FILES" == "x" ]; then 
   # List of ungrouped files is empty, so that's a pass.
   echo pass > $OUTFILE; 
 else 

--- a/files/linuxcontrols/scripts/f0004.sh
+++ b/files/linuxcontrols/scripts/f0004.sh
@@ -5,7 +5,7 @@
 
 COMMAND=`cat /etc/shadow | awk -F: '($2=="") {print $1}'`
 
-if [ x$COMMAND == x ]; then 
+if [ "x$COMMAND" == "x" ]; then 
   echo pass;
 else 
   echo fail;

--- a/files/linuxcontrols/scripts/f0005.sh
+++ b/files/linuxcontrols/scripts/f0005.sh
@@ -5,7 +5,7 @@
 
 COMMAND=`grep '^+:' /etc/passwd`
 
-if [ x$COMMAND == x ]; then 
+if [ "x$COMMAND" == "x" ]; then 
   echo pass;
 else 
   echo fail;

--- a/files/linuxcontrols/scripts/f0006.sh
+++ b/files/linuxcontrols/scripts/f0006.sh
@@ -5,7 +5,7 @@
 
 COMMAND=`grep '^+:' /etc/shadow`
 
-if [ x$COMMAND == x ]; then 
+if [ "x$COMMAND" == "x" ]; then 
   echo pass;
 else 
   echo fail;

--- a/files/linuxcontrols/scripts/f0007.sh
+++ b/files/linuxcontrols/scripts/f0007.sh
@@ -5,7 +5,7 @@
 
 COMMAND=`grep '^+:' /etc/group`
 
-if [ x$COMMAND == x ]; then 
+if [ "x$COMMAND" == "x" ]; then 
   echo pass;
 else 
   echo fail;

--- a/files/linuxcontrols/scripts/f0008.sh
+++ b/files/linuxcontrols/scripts/f0008.sh
@@ -5,7 +5,7 @@
 
 COMMAND=`awk -F: '($3 == 0) { print $1 }' /etc/passwd | grep -v '^root$'`
 
-if [ x$COMMAND == x ]; then 
+if [ "x$COMMAND" == "x" ]; then 
   echo pass;
 else 
   echo fail;

--- a/files/linuxcontrols/scripts/f0009.sh
+++ b/files/linuxcontrols/scripts/f0009.sh
@@ -8,7 +8,7 @@ COMMAND=`awk -F: '($3>499 && $7!=/sbin/nologin) {print $6}' /etc/passwd`
 RESULTS="pass"
 
 for dir in $COMMAND; do
-  if [ `find $dir -nowarn -maxdepth 0 -type d -perm /g+w,o+w 2>/dev/null`x != x ]; then
+  if [ "`find $dir -nowarn -maxdepth 0 -type d -perm /g+w,o+w 2>/dev/null`x" != "x" ]; then
     RESULTS="fail";
   fi;
 done

--- a/files/linuxcontrols/scripts/f0010.sh
+++ b/files/linuxcontrols/scripts/f0010.sh
@@ -8,7 +8,7 @@ COMMAND=`awk -F: '($3>499 && $7!=/sbin/nologin) {print $6}' /etc/passwd`
 RESULTS="pass"
 
 for dir in $COMMAND; do
-  if [ `find $dir -maxdepth 1 -type f -name ".*" -perm /g+w,o+w 2>/dev/null`x != x ]; then
+  if [ "`find $dir -maxdepth 1 -type f -name ".*" -perm /g+w,o+w 2>/dev/null`x" != "x" ]; then
     RESULTS="fail";
   fi;
 done

--- a/files/linuxcontrols/scripts/f0011.sh
+++ b/files/linuxcontrols/scripts/f0011.sh
@@ -8,7 +8,7 @@ COMMAND=`awk -F: '($3>499 && $7!=/sbin/nologin) {print $6}' /etc/passwd`
 RESULTS="pass"
 
 for dir in $COMMAND; do
-  if [ `find $dir -maxdepth 1 -type f -name ".netrc" -perm /g+rwx,o+rwx 2>/dev/null`x != x ]; then
+  if [ "`find $dir -maxdepth 1 -type f -name ".netrc" -perm /g+rwx,o+rwx 2>/dev/null`x" != "x" ]; then
     RESULTS="fail";
   fi;
 done

--- a/files/linuxcontrols/scripts/f0012.sh
+++ b/files/linuxcontrols/scripts/f0012.sh
@@ -8,7 +8,7 @@ COMMAND=`awk -F: '($3>499 && $7!=/sbin/nologin) {print $6}' /etc/passwd`
 RESULTS="pass"
 
 for dir in $COMMAND; do
-  if [ `find $dir -maxdepth 1 -type f -name ".rhosts" 2>/dev/null`x != x ]; then
+  if [ "`find $dir -maxdepth 1 -type f -name ".rhosts" 2>/dev/null`x" != "x" ]; then
     RESULTS="fail";
   fi;
 done

--- a/files/linuxcontrols/scripts/f0014.sh
+++ b/files/linuxcontrols/scripts/f0014.sh
@@ -5,7 +5,7 @@
 
 COMMAND=`awk -F: '{if ($6=="") print $1}' /etc/passwd`
 
-if [ x$COMMAND = x ]; then
+if [ "x$COMMAND" = "x" ]; then
   echo "pass";
 else
   echo "fail";


### PR DESCRIPTION
At least some of the if statements broke when encountering multipart strings (like multiple files found with a find command line). I originally bumped into this when trying to figure out why fact script 0002 (find files with unknown owner) doesn't work.

Without modifications (and with an alien file around) it acts like this:

```
[vagrant@client1 ~]$ ls -l
total 1
-rw------- 1    4567 vagrant  0 Jan 14 11:52 my_unowned_file
[vagrant@client1 ~]$ sudo sh /usr/local/sbin/f0002.sh 
/usr/local/sbin/f0002.sh: line 9: [: too many arguments
```

By adding quotes it starts acting like it should.
